### PR TITLE
Improve memory op tests

### DIFF
--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -196,9 +196,10 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.lt_s\n"
-                   "    local.set $t\n"
+                   "    local.set $tmp\n"
                    "    local.get $base\n"
-                   "    local.get $t\n"
+                   "    local.get $tmp\n"
+                   "    i64.extend_i32_u\n"
                    "    i64.store offset=%zu\n",
                    rd, rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -211,9 +212,10 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.lt_u\n"
-                   "    local.set $t\n"
+                   "    local.set $tmp\n"
                    "    local.get $base\n"
-                   "    local.get $t\n"
+                   "    local.get $tmp\n"
+                   "    i64.extend_i32_u\n"
                    "    i64.store offset=%zu\n",
                    rd, rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -303,7 +305,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shl\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, sa,
                    (size_t)GPR_OFFSET(rt), sa,
@@ -316,7 +320,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shr_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, sa,
                    (size_t)GPR_OFFSET(rt), sa,
@@ -329,7 +335,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shr_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, sa,
                    (size_t)GPR_OFFSET(rt), sa,
@@ -342,7 +350,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shl\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, 32 + sa,
                    (size_t)GPR_OFFSET(rt), 32 + sa,
@@ -355,7 +365,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shr_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, 32 + sa,
                    (size_t)GPR_OFFSET(rt), 32 + sa,
@@ -368,7 +380,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.const %u\n"
                    "    i64.shr_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, 32 + sa,
                    (size_t)GPR_OFFSET(rt), 32 + sa,
@@ -380,7 +394,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shl\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -393,7 +409,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shr_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -406,7 +424,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shr_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -419,7 +439,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shl\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -432,7 +454,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shr_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -445,7 +469,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.shr_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rd, rt, rs,
                    (size_t)GPR_OFFSET(rt),
@@ -458,13 +484,14 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.mul\n"
-                   "    local.tee $t\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.const 32\n"
                    "    i64.shr_s\n"
-                   "    local.get $base\n"
                    "    i64.store offset=%zu\n"
-                   "    local.get $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -478,13 +505,14 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.mul\n"
-                   "    local.tee $t\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.const 32\n"
                    "    i64.shr_u\n"
-                   "    local.get $base\n"
                    "    i64.store offset=%zu\n"
-                   "    local.get $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -498,12 +526,16 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.div_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.rem_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -519,12 +551,16 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.div_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.rem_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -541,11 +577,11 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.mul\n"
                    "    local.set $t\n"
+                   "    local.get $base\n"
                    "    i64.const 0\n"
-                   "    local.get $base\n"
                    "    i64.store offset=%zu\n"
-                   "    local.get $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -560,11 +596,11 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.mul\n"
                    "    local.set $t\n"
+                   "    local.get $base\n"
                    "    i64.const 0\n"
-                   "    local.get $base\n"
                    "    i64.store offset=%zu\n"
-                   "    local.get $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -578,12 +614,16 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.div_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.rem_s\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -599,12 +639,16 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.div_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.rem_u\n"
+                   "    local.set $t\n"
                    "    local.get $base\n"
+                   "    local.get $t\n"
                    "    i64.store offset=%zu\n",
                    rs, rt,
                    (size_t)GPR_OFFSET(rs),
@@ -617,8 +661,8 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         case 0x10:
             append(buf, size,
                    "    ;; mfhi r%u\n"
-                   "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base\n"
+                   "    local.get $base i64.load offset=%zu\n"
                    "    i64.store offset=%zu\n",
                    rd,
                    (size_t)HI_OFFSET,
@@ -627,8 +671,8 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         case 0x11:
             append(buf, size,
                    "    ;; mthi r%u\n"
-                   "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base\n"
+                   "    local.get $base i64.load offset=%zu\n"
                    "    i64.store offset=%zu\n",
                    rs,
                    (size_t)GPR_OFFSET(rs),
@@ -637,8 +681,8 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         case 0x12:
             append(buf, size,
                    "    ;; mflo r%u\n"
-                   "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base\n"
+                   "    local.get $base i64.load offset=%zu\n"
                    "    i64.store offset=%zu\n",
                    rd,
                    (size_t)LO_OFFSET,
@@ -647,8 +691,8 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         case 0x13:
             append(buf, size,
                    "    ;; mtlo r%u\n"
-                   "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base\n"
+                   "    local.get $base i64.load offset=%zu\n"
                    "    i64.store offset=%zu\n",
                    rs,
                    (size_t)GPR_OFFSET(rs),
@@ -709,8 +753,11 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i64.load\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -722,8 +769,11 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i64.load\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -773,11 +823,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         break;
     case 0x0f:
         append(buf, size,
-               "    ;; lui r%u, %d\n"
+               "    ;; lui r%u, %u\n"
                "    local.get $base\n"
-               "    i64.const %d\n"
+               "    i64.const %u\n"
                "    i64.store offset=%zu\n",
-               rt, imm, (uint16_t)imm << 16,
+               rt, (uint32_t)(uint16_t)imm,
+               (uint32_t)(uint16_t)imm << 16,
                (size_t)GPR_OFFSET(rt));
         break;
     case 0x0a:
@@ -786,9 +837,10 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.lt_s\n"
-               "    local.set $t\n"
+               "    local.set $tmp\n"
                "    local.get $base\n"
-               "    local.get $t\n"
+               "    local.get $tmp\n"
+               "    i64.extend_i32_u\n"
                "    i64.store offset=%zu\n",
                rt, rs, imm,
                (size_t)GPR_OFFSET(rs), imm,
@@ -800,9 +852,10 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.lt_u\n"
-               "    local.set $t\n"
+               "    local.set $tmp\n"
                "    local.get $base\n"
-               "    local.get $t\n"
+               "    local.get $tmp\n"
+               "    i64.extend_i32_u\n"
                "    i64.store offset=%zu\n",
                rt, rs, imm,
                (size_t)GPR_OFFSET(rs), imm,
@@ -814,9 +867,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load8_s\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -828,9 +884,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load16_s\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -842,9 +901,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -856,9 +918,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -870,9 +935,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load8_u\n"
                "    i64.extend_i32_u\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -884,9 +952,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load16_u\n"
                "    i64.extend_i32_u\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -898,9 +969,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -912,9 +986,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load\n"
                "    i64.extend_i32_u\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -926,9 +1003,12 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i32.load\n"
                "    i64.extend_i32_s\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -940,7 +1020,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store8\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -952,7 +1034,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store16\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -964,7 +1048,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -976,7 +1062,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -988,6 +1076,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
                "    i64.store\n",
                rt, imm, rs,
@@ -1000,6 +1089,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
                "    i64.store\n",
                rt, imm, rs,
@@ -1012,7 +1102,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -1032,8 +1124,11 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    i64.load\n"
+               "    local.set $t\n"
                "    local.get $base\n"
+               "    local.get $t\n"
                "    i64.store offset=%zu\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -1045,7 +1140,9 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
+               "    i32.wrap_i64\n"
                "    i32.store\n",
                rt, imm, rs,
                (size_t)GPR_OFFSET(rs), imm,
@@ -1062,6 +1159,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"
+               "    i32.wrap_i64\n"
                "    local.get $base i64.load offset=%zu\n"
                "    i64.store\n",
                rt, imm, rs,

--- a/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
+++ b/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
@@ -12,10 +12,27 @@ const statePath = process.argv[3];
 const wasmBuffer = fs.readFileSync(wasmPath);
 const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
 
-const GPR_OFFSET = 320; // offsetof(struct new_dynarec_hot_state, regs)
-const HI_OFFSET = 576;  // offsetof(struct new_dynarec_hot_state, hi)
-const LO_OFFSET = 584;  // offsetof(struct new_dynarec_hot_state, lo)
-const PC_OFFSET = 264;  // offsetof(struct new_dynarec_hot_state, pcaddr)
+// Parse offset constants from the asm_defines header generated during the
+// build.  This mirrors the gawk logic in the main Makefile that creates the
+// same table for the assembly dynarec backends so the values stay in sync
+// even when the structure layout changes or the build targets another
+// architecture.
+const asmPath = path.join(__dirname, '..', '..', 'src', 'device', 'r4300',
+                          'new_dynarec', 'arm64', 'asm_defines_gas.h');
+const asmText = fs.readFileSync(asmPath, 'utf8');
+
+function parseOffset(name) {
+  const regex = new RegExp(`#define\\s+${name}\\s+\\((0x[0-9a-fA-F]+)\\)`);
+  const match = asmText.match(regex);
+  if (!match)
+    throw new Error(`Unable to find ${name} in ${asmPath}`);
+  return parseInt(match[1], 16);
+}
+
+const GPR_OFFSET = parseOffset('offsetof_struct_new_dynarec_hot_state_regs');
+const HI_OFFSET = parseOffset('offsetof_struct_new_dynarec_hot_state_hi');
+const LO_OFFSET = parseOffset('offsetof_struct_new_dynarec_hot_state_lo');
+const PC_OFFSET = parseOffset('offsetof_struct_new_dynarec_hot_state_pcaddr');
 
 (async () => {
   const env = {

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -70,10 +70,31 @@ static void run_asm_test(const char *name, const uint32_t *code, size_t count,
     int ret = system(cmd);
     ck_assert_msg(ret == 0, "wat2wasm failed: %d", ret);
 
-    /* Execution of the generated WebAssembly is not implemented yet. Normally
-     * this test would run the module and compare CPU state using a helper
-     * script. Until execution support exists we simply confirm that the WAT
-     * assembles successfully. */
+    FILE *json = fopen(json_path, "w");
+    ck_assert_ptr_nonnull(json);
+    fprintf(json, "{\n  \"initial\": {\"regs\": [");
+    for (int i = 0; i < 32; i++) {
+        fprintf(json, "%s%llu", i ? ", " : "", (unsigned long long)initial->regs[i]);
+    }
+    fprintf(json, "], \"hi\": %llu, \"lo\": %llu, \"pcaddr\": %u},\n",
+            (unsigned long long)initial->hi,
+            (unsigned long long)initial->lo,
+            initial->pcaddr);
+    fprintf(json, "  \"expected\": {\"regs\": [");
+    for (int i = 0; i < 32; i++) {
+        fprintf(json, "%s%llu", i ? ", " : "", (unsigned long long)expected->regs[i]);
+    }
+    fprintf(json, "], \"hi\": %llu, \"lo\": %llu, \"pcaddr\": %u}\n}\n",
+            (unsigned long long)expected->hi,
+            (unsigned long long)expected->lo,
+            expected->pcaddr);
+    fclose(json);
+
+    snprintf(cmd, sizeof(cmd),
+             "node mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js %s %s",
+             wasm_path, json_path);
+    ret = system(cmd);
+    ck_assert_msg(ret == 0, "WebAssembly execution failed: %d", ret);
 
     wasm_dynarec_cleanup();
     free(cpu);
@@ -169,7 +190,7 @@ START_TEST(test_more_opcodes)
     expect.regs[10] = 0x0;
     expect.regs[11] = 0xfff0;
     expect.regs[12] = 0xfff0;
-    expect.regs[13] = 0xffff000f;
+    expect.regs[13] = 0xffffffffffff000fULL;
     expect.regs[14] = 0xf00;
     expect.regs[15] = 0xff0;
     expect.regs[16] = 0xff0;
@@ -237,9 +258,102 @@ START_TEST(test_more_opcodes)
     memset(&init, 0, sizeof(init));
     memset(&expect, 0, sizeof(expect));
     expect.regs[4]  = 1;
+    expect.regs[5]  = 2;
     expect.regs[6]  = 3;
-    expect.regs[31] = 0x80000008;
+    expect.regs[31] = 0xffffffff80000008ULL;
+    expect.pcaddr   = 0x80000008;
     run_asm_test("jal", jal_block, sizeof(jal_block)/4, &init, &expect);
+}
+END_TEST
+
+START_TEST(test_memory_ops)
+{
+    /* Basic loads and stores */
+    const uint32_t mem_block[] = {
+        0x3c080000, /* lui t0, 0 */
+        0x35082000, /* ori t0, t0, 0x2000 */
+        0x3c091234, /* lui t1, 0x1234 */
+        0x35295678, /* ori t1, t1, 0x5678 */
+        0xad090000, /* sw t1, 0(t0) */
+        0x810a0000, /* lb t2, 0(t0) */
+        0x850b0000, /* lh t3, 0(t0) */
+        0x8d0c0000, /* lw t4, 0(t0) */
+        0x910d0000, /* lbu t5, 0(t0) */
+        0x950e0000, /* lhu t6, 0(t0) */
+        0x9d0f0000, /* lwu t7, 0(t0) */
+        0x3c09ffff, /* lui t1, 0xffff */
+        0x3529ffff, /* ori t1, t1, 0xffff */
+        0xad090004, /* sw t1, 4(t0) */
+        0x81100004, /* lb s0, 4(t0) */
+        0x91110004, /* lbu s1, 4(t0) */
+        0x85120004, /* lh s2, 4(t0) */
+        0x95130004, /* lhu s3, 4(t0) */
+        0x8d140004, /* lw s4, 4(t0) */
+        0x9d150004, /* lwu s5, 4(t0) */
+        0x3c091234, /* lui t1, 0x1234 */
+        0x35295678, /* ori t1, t1, 0x5678 */
+        0x0009483c, /* dsll32 t1, t1, 0 */
+        0x3c0a8765, /* lui t2, 0x8765 */
+        0x354a4321, /* ori t2, t2, 0x4321 */
+        0x012a4825, /* or t1, t1, t2 */
+        0xfd090008, /* sd t1, 8(t0) */
+        0xdd160008, /* ld s6, 8(t0) */
+        0x00000000  /* nop */
+    };
+    struct cpu_state init = {0};
+    struct cpu_state expect = {0};
+    expect.regs[8]  = 0x2000;                 /* t0 */
+    expect.regs[9]  = 0x1234567887654321ULL;  /* t1 */
+    expect.regs[10] = 0x87654321;             /* t2 */
+    expect.regs[11] = 0x5678;                 /* t3 */
+    expect.regs[12] = 0x12345678;             /* t4 */
+    expect.regs[13] = 0x78;                   /* t5 */
+    expect.regs[14] = 0x5678;                 /* t6 */
+    expect.regs[15] = 0x12345678;             /* t7 */
+    expect.regs[16] = 0xffffffffffffffffULL;  /* s0 */
+    expect.regs[17] = 0xff;                   /* s1 */
+    expect.regs[18] = 0xffffffffffffffffULL;  /* s2 */
+    expect.regs[19] = 0xffff;                 /* s3 */
+    expect.regs[20] = 0xffffffffffffffffULL;  /* s4 */
+    expect.regs[21] = 0xffffffff;             /* s5 */
+    expect.regs[22] = 0x1234567887654321ULL;  /* s6 */
+    run_asm_test("memory", mem_block, sizeof(mem_block)/4, &init, &expect);
+}
+END_TEST
+
+START_TEST(test_delay_slots)
+{
+    /* Branch taken - delay slot must execute */
+    const uint32_t taken_block[] = {
+        0x20080000, /* addi t0, zero, 0 */
+        0x11000002, /* beq  t0, zero, 2 */
+        0x20090005, /* addi t1, zero, 5  (delay slot) */
+        0x2009000a, /* addi t1, zero, 10 (skipped) */
+        0x2009000f, /* addi t1, zero, 15 */
+        0x00000000  /* nop */
+    };
+    struct cpu_state init = {0};
+    struct cpu_state expect = {0};
+    expect.regs[8] = 0;  /* t0 */
+    expect.regs[9] = 15; /* t1 */
+    run_asm_test("delay_beq_taken", taken_block, sizeof(taken_block)/4,
+                 &init, &expect);
+
+    /* Branch not taken - delay slot executes before fall-through */
+    const uint32_t not_block[] = {
+        0x20080001, /* addi t0, zero, 1 */
+        0x15000003, /* bne  t0, zero, 3 */
+        0x20090001, /* addi t1, zero, 1  (delay slot) */
+        0x21290001, /* addi t1, t1, 1 */
+        0x08000006, /* j 0x18 */
+        0x20090004, /* addi t1, zero, 4 (skipped) */
+        0x00000000  /* nop */
+    };
+    memset(&init, 0, sizeof(init));
+    memset(&expect, 0, sizeof(expect));
+    expect.regs[8] = 1;  /* t0 */
+    expect.regs[9] = 4;  /* t1 after delay slot and jump */
+    run_asm_test("delay_bne_not", not_block, sizeof(not_block)/4, &init, &expect);
 }
 END_TEST
 
@@ -248,6 +362,10 @@ Suite *create_suite(void)
     Suite *s = suite_create("WebAssembly Dynarec");
     TCase *tc_core = tcase_create("Core");
     tcase_add_test(tc_core, test_compile_example);
+    tcase_add_test(tc_core, test_opcode_scenarios);
+    tcase_add_test(tc_core, test_more_opcodes);
+    tcase_add_test(tc_core, test_memory_ops);
+    tcase_add_test(tc_core, test_delay_slots);
     suite_add_tcase(s, tc_core);
     return s;
 }


### PR DESCRIPTION
## Summary
- add coverage for basic memory instructions
- fix operand order for load results in wasm dynarec

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`


------
https://chatgpt.com/codex/tasks/task_e_6840a0b562c8832b998412caf794e7fe