### PR TITLE
Implement more wasm dynarec opcodes

### DIFF
--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -8,6 +8,8 @@ This document tracks which MIPS instructions are currently handled by the experi
 |--------|
 | ADD |
 | ADDI |
+| ADDIU |
+| ADDU |
 | AND |
 | ANDI |
 | BEQ |
@@ -26,6 +28,8 @@ This document tracks which MIPS instructions are currently handled by the experi
 | CACHE |
 | DADD |
 | DADDI |
+| DADDIU |
+| DADDU |
 | DDIV |
 | DDIVU |
 | DIV |
@@ -42,6 +46,7 @@ This document tracks which MIPS instructions are currently handled by the experi
 | DSRL32 |
 | DSRLV |
 | DSUB |
+| DSUBU |
 | J |
 | JALR |
 | JR |
@@ -67,6 +72,7 @@ This document tracks which MIPS instructions are currently handled by the experi
 | MULT |
 | MULTU |
 | NOR |
+| NOP |
 | OR |
 | ORI |
 | PREF |
@@ -87,6 +93,7 @@ This document tracks which MIPS instructions are currently handled by the experi
 | SRL |
 | SRLV |
 | SUB |
+| SUBU |
 | SW |
 | SWL |
 | SWR |
@@ -101,8 +108,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 |--------|
 | ABS_D |
 | ABS_S |
-| ADDIU |
-| ADDU |
 | ADD_D |
 | ADD_S |
 | CEIL_L_D |
@@ -155,8 +160,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | C_ULT_S |
 | C_UN_D |
 | C_UN_S |
-| DADDIU |
-| DADDU |
 | DCFC1 |
 | DCTC1 |
 | DIV_D |
@@ -166,7 +169,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | DMFC2 |
 | DMTC1 |
 | DMTC2 |
-| DSUBU |
 | ERET |
 | FLOOR_L_D |
 | FLOOR_L_S |
@@ -187,7 +189,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | NEG_D |
 | NEG_S |
 | NI |
-| NOP |
 | RESERVED |
 | RESERVED_COP2 |
 | ROUND_L_D |
@@ -197,7 +198,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | SDC1 |
 | SQRT_D |
 | SQRT_S |
-| SUBU |
 | SUB_D |
 | SUB_S |
 | SWC1 |

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -68,7 +68,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
     switch (op) {
     case 0x00:
         switch (funct) {
-        case 0x20: case 0x21:
+        case 0x20:
             append(buf, size,
                    "    ;; add r%u, r%u, r%u\n"
                    "    local.get $base i64.load offset=%zu\n"
@@ -83,7 +83,22 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    (size_t)GPR_OFFSET(rt),
                    (size_t)GPR_OFFSET(rd));
             break;
-        case 0x2c: case 0x2d:
+        case 0x21:
+            append(buf, size,
+                   "    ;; addu r%u, r%u, r%u\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    i64.add\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
+                   "    i64.store offset=%zu\n",
+                   rd, rs, rt,
+                   (size_t)GPR_OFFSET(rs),
+                   (size_t)GPR_OFFSET(rt),
+                   (size_t)GPR_OFFSET(rd));
+            break;
+        case 0x2c:
             append(buf, size,
                    "    ;; dadd r%u, r%u, r%u\n"
                    "    local.get $base i64.load offset=%zu\n"
@@ -98,7 +113,22 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    (size_t)GPR_OFFSET(rt),
                    (size_t)GPR_OFFSET(rd));
             break;
-        case 0x2e: case 0x2f:
+        case 0x2d:
+            append(buf, size,
+                   "    ;; daddu r%u, r%u, r%u\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    i64.add\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
+                   "    i64.store offset=%zu\n",
+                   rd, rs, rt,
+                   (size_t)GPR_OFFSET(rs),
+                   (size_t)GPR_OFFSET(rt),
+                   (size_t)GPR_OFFSET(rd));
+            break;
+        case 0x2e:
             append(buf, size,
                    "    ;; dsub r%u, r%u, r%u\n"
                    "    local.get $base i64.load offset=%zu\n"
@@ -113,9 +143,39 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    (size_t)GPR_OFFSET(rt),
                    (size_t)GPR_OFFSET(rd));
             break;
-        case 0x22: case 0x23:
+        case 0x2f:
+            append(buf, size,
+                   "    ;; dsubu r%u, r%u, r%u\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    i64.sub\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
+                   "    i64.store offset=%zu\n",
+                   rd, rs, rt,
+                   (size_t)GPR_OFFSET(rs),
+                   (size_t)GPR_OFFSET(rt),
+                   (size_t)GPR_OFFSET(rd));
+            break;
+        case 0x22:
             append(buf, size,
                    "    ;; sub r%u, r%u, r%u\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    local.get $base i64.load offset=%zu\n"
+                   "    i64.sub\n"
+                   "    local.set $t\n"
+                   "    local.get $base\n"
+                   "    local.get $t\n"
+                   "    i64.store offset=%zu\n",
+                   rd, rs, rt,
+                   (size_t)GPR_OFFSET(rs),
+                   (size_t)GPR_OFFSET(rt),
+                   (size_t)GPR_OFFSET(rd));
+            break;
+        case 0x23:
+            append(buf, size,
+                   "    ;; subu r%u, r%u, r%u\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    local.get $base i64.load offset=%zu\n"
                    "    i64.sub\n"
@@ -255,18 +315,22 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
             break;
         case 0x00: {
             uint32_t sa = (inst >> 6) & 0x1f;
-            append(buf, size,
-                   "    ;; sll r%u, r%u, %u\n"
-                   "    local.get $base i64.load offset=%zu\n"
-                   "    i64.const %u\n"
-                   "    i64.shl\n"
-                   "    local.set $t\n"
-                   "    local.get $base\n"
-                   "    local.get $t\n"
-                   "    i64.store offset=%zu\n",
-                   rd, rt, sa,
-                   (size_t)GPR_OFFSET(rt), sa,
-                   (size_t)GPR_OFFSET(rd));
+            if (rd == 0 && rt == 0 && sa == 0) {
+                append(buf, size, "    ;; nop\n");
+            } else {
+                append(buf, size,
+                       "    ;; sll r%u, r%u, %u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i64.const %u\n"
+                       "    i64.shl\n"
+                       "    local.set $t\n"
+                       "    local.get $base\n"
+                       "    local.get $t\n"
+                       "    i64.store offset=%zu\n",
+                       rd, rt, sa,
+                       (size_t)GPR_OFFSET(rt), sa,
+                       (size_t)GPR_OFFSET(rd));
+            }
             break; }
         case 0x02: {
             uint32_t sa = (inst >> 6) & 0x1f;
@@ -719,7 +783,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
         }
         break;
 
-    case 0x08: case 0x09:
+    case 0x08:
         append(buf, size,
                "    ;; addi r%u, r%u, %d\n"
                "    local.get $base i64.load offset=%zu\n"
@@ -733,9 +797,37 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                (size_t)GPR_OFFSET(rs), imm,
                (size_t)GPR_OFFSET(rt));
         break;
-    case 0x18: case 0x19:
+    case 0x09:
+        append(buf, size,
+               "    ;; addiu r%u, r%u, %d\n"
+               "    local.get $base i64.load offset=%zu\n"
+               "    i64.const %d\n"
+               "    i64.add\n"
+               "    local.set $t\n"
+               "    local.get $base\n"
+               "    local.get $t\n"
+               "    i64.store offset=%zu\n",
+               rt, rs, imm,
+               (size_t)GPR_OFFSET(rs), imm,
+               (size_t)GPR_OFFSET(rt));
+        break;
+    case 0x18:
         append(buf, size,
                "    ;; daddi r%u, r%u, %d\n"
+               "    local.get $base i64.load offset=%zu\n"
+               "    i64.const %d\n"
+               "    i64.add\n"
+               "    local.set $t\n"
+               "    local.get $base\n"
+               "    local.get $t\n"
+               "    i64.store offset=%zu\n",
+               rt, rs, imm,
+               (size_t)GPR_OFFSET(rs), imm,
+               (size_t)GPR_OFFSET(rt));
+        break;
+    case 0x19:
+        append(buf, size,
+               "    ;; daddiu r%u, r%u, %d\n"
                "    local.get $base i64.load offset=%zu\n"
                "    i64.const %d\n"
                "    i64.add\n"

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -266,6 +266,29 @@ START_TEST(test_more_opcodes)
 }
 END_TEST
 
+START_TEST(test_unsigned_ops)
+{
+    const uint32_t block[] = {
+        0x24080001, /* addiu t0, zero, 1 */
+        0x64090002, /* daddiu t1, zero, 2 */
+        0x01095021, /* addu t2, t0, t1 */
+        0x01285823, /* subu t3, t1, t0 */
+        0x0129602d, /* daddu t4, t1, t1 */
+        0x0128682f, /* dsubu t5, t1, t0 */
+        0x00000000  /* nop */
+    };
+    struct cpu_state init = {0};
+    struct cpu_state expect = {0};
+    expect.regs[8] = 1;  /* t0 */
+    expect.regs[9] = 2;  /* t1 */
+    expect.regs[10] = 3; /* t2 */
+    expect.regs[11] = 1; /* t3 */
+    expect.regs[12] = 4; /* t4 */
+    expect.regs[13] = 1; /* t5 */
+    run_asm_test("unsigned", block, sizeof(block)/4, &init, &expect);
+}
+END_TEST
+
 START_TEST(test_memory_ops)
 {
     /* Basic loads and stores */
@@ -364,6 +387,7 @@ Suite *create_suite(void)
     tcase_add_test(tc_core, test_compile_example);
     tcase_add_test(tc_core, test_opcode_scenarios);
     tcase_add_test(tc_core, test_more_opcodes);
+    tcase_add_test(tc_core, test_unsigned_ops);
     tcase_add_test(tc_core, test_memory_ops);
     tcase_add_test(tc_core, test_delay_slots);
     suite_add_tcase(s, tc_core);


### PR DESCRIPTION
## Summary
- handle nop, addiu/addu, daddiu/daddu, subu and dsubu
- add a new unsigned arithmetic test
- document opcode coverage progress

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6840b9af6434832b9cd1ce50cb58526f