### PR TITLE
Fix CP1 arithmetic register decoding

### DIFF
--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -112,15 +112,25 @@ This document tracks which MIPS instructions are currently handled by the experi
 | SYSCALL |
 | XOR |
 | XORI |
+| ABS_D |
+| ABS_S |
+| ADD_D |
+| ADD_S |
+| DIV_D |
+| DIV_S |
+| MOV_D |
+| MOV_S |
+| MUL_D |
+| MUL_S |
+| NEG_D |
+| NEG_S |
+| SUB_D |
+| SUB_S |
 
 ## Not yet implemented
 
 | Opcode |
 |--------|
-| ABS_D |
-| ABS_S |
-| ADD_D |
-| ADD_S |
 | CEIL_L_D |
 | CEIL_L_S |
 | CEIL_W_D |
@@ -173,8 +183,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | C_UN_S |
 | DCFC1 |
 | DCTC1 |
-| DIV_D |
-| DIV_S |
 | DMFC2 |
 | DMTC2 |
 | ERET |
@@ -183,13 +191,7 @@ This document tracks which MIPS instructions are currently handled by the experi
 | FLOOR_W_D |
 | FLOOR_W_S |
 | MFC2 |
-| MOV_D |
-| MOV_S |
 | MTC2 |
-| MUL_D |
-| MUL_S |
-| NEG_D |
-| NEG_S |
 | NI |
 | RESERVED |
 | RESERVED_COP2 |
@@ -199,8 +201,6 @@ This document tracks which MIPS instructions are currently handled by the experi
 | ROUND_W_S |
 | SQRT_D |
 | SQRT_S |
-| SUB_D |
-| SUB_S |
 | TLBP |
 | TLBR |
 | TLBWI |

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -65,6 +65,7 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
     uint32_t rs = (inst >> 21) & 0x1f;
     uint32_t rt = (inst >> 16) & 0x1f;
     uint32_t rd = (inst >> 11) & 0x1f;
+    uint32_t fd = (inst >> 6) & 0x1f;
     uint32_t funct = inst & 0x3f;
     int16_t imm = inst & 0xffff;
 
@@ -1058,6 +1059,284 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                    (size_t)CP1_DOUBLE_OFFSET(rd),
                    (size_t)GPR_OFFSET(rt));
             break;
+        case 0x10: {
+            uint32_t fs = (inst >> 11) & 0x1f;
+            uint32_t ft = (inst >> 16) & 0x1f;
+            switch (funct) {
+            case 0x00:
+                append(buf, size,
+                       "    ;; add.s f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.add\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs),
+                       (size_t)CP1_SIMPLE_OFFSET(ft));
+                break;
+            case 0x01:
+                append(buf, size,
+                       "    ;; sub.s f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.sub\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs),
+                       (size_t)CP1_SIMPLE_OFFSET(ft));
+                break;
+            case 0x02:
+                append(buf, size,
+                       "    ;; mul.s f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.mul\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs),
+                       (size_t)CP1_SIMPLE_OFFSET(ft));
+                break;
+            case 0x03:
+                append(buf, size,
+                       "    ;; div.s f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.div\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs),
+                       (size_t)CP1_SIMPLE_OFFSET(ft));
+                break;
+            case 0x05:
+                append(buf, size,
+                       "    ;; abs.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.abs\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x06:
+                append(buf, size,
+                       "    ;; mov.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x07:
+                append(buf, size,
+                       "    ;; neg.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.neg\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            default:
+                append(buf, size,
+                       "    ;; unsupported COP1 fmt %u funct %u\n", sub, funct);
+                break;
+            }
+            break; }
+        case 0x11: {
+            uint32_t fs = (inst >> 11) & 0x1f;
+            uint32_t ft = (inst >> 16) & 0x1f;
+            switch (funct) {
+            case 0x00:
+                append(buf, size,
+                       "    ;; add.d f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.add\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs),
+                       (size_t)CP1_DOUBLE_OFFSET(ft));
+                break;
+            case 0x01:
+                append(buf, size,
+                       "    ;; sub.d f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.sub\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs),
+                       (size_t)CP1_DOUBLE_OFFSET(ft));
+                break;
+            case 0x02:
+                append(buf, size,
+                       "    ;; mul.d f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.mul\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs),
+                       (size_t)CP1_DOUBLE_OFFSET(ft));
+                break;
+            case 0x03:
+                append(buf, size,
+                       "    ;; div.d f%u, f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.div\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs, ft,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs),
+                       (size_t)CP1_DOUBLE_OFFSET(ft));
+                break;
+            case 0x05:
+                append(buf, size,
+                       "    ;; abs.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.abs\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x06:
+                append(buf, size,
+                       "    ;; mov.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x07:
+                append(buf, size,
+                       "    ;; neg.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.neg\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            default:
+                append(buf, size,
+                       "    ;; unsupported COP1 fmt %u funct %u\n", sub, funct);
+                break;
+            }
+            break; }
         default:
             append(buf, size,
                    "    ;; unsupported COP1 subop %u\n", sub);

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -659,6 +659,49 @@ START_TEST(test_cp1_moves)
 }
 END_TEST
 
+START_TEST(test_cp1_arith)
+{
+    const uint32_t block[] = {
+        0x46010080, /* add.s f2, f0, f1 */
+        0x460100c1, /* sub.s f3, f0, f1 */
+        0x46010102, /* mul.s f4, f0, f1 */
+        0x46010143, /* div.s f5, f0, f1 */
+        0x46001985, /* abs.s f6, f3 */
+        0x460021c7, /* neg.s f7, f4 */
+        0x46002a06, /* mov.s f8, f5 */
+        0x462b5300, /* add.d f12, f10, f11 */
+        0x462b5341, /* sub.d f13, f10, f11 */
+        0x462b5382, /* mul.d f14, f10, f11 */
+        0x462b53c3, /* div.d f15, f10, f11 */
+        0x46206c05, /* abs.d f16, f13 */
+        0x46207447, /* neg.d f17, f14 */
+        0x46207c86, /* mov.d f18, f15 */
+        0x00000000  /* nop */
+    };
+    struct cpu_state init = {0};
+    init.cp1[0]  = 0x3f800000ULL;           /* 1.0f */
+    init.cp1[1]  = 0x40000000ULL;           /* 2.0f */
+    init.cp1[10] = 0x3ff8000000000000ULL;   /* 1.5 */
+    init.cp1[11] = 0x4000000000000000ULL;   /* 2.0 */
+    struct cpu_state expect = init;
+    expect.cp1[2]  = 0x40400000ULL;         /* 3.0f */
+    expect.cp1[3]  = 0xbf800000ULL;         /* -1.0f */
+    expect.cp1[4]  = 0x40000000ULL;         /* 2.0f */
+    expect.cp1[5]  = 0x3f000000ULL;         /* 0.5f */
+    expect.cp1[6]  = 0x3f800000ULL;         /* 1.0f */
+    expect.cp1[7]  = 0xc0000000ULL;         /* -2.0f */
+    expect.cp1[8]  = 0x3f000000ULL;         /* 0.5f */
+    expect.cp1[12] = 0x400c000000000000ULL; /* 3.5 */
+    expect.cp1[13] = 0xbfe0000000000000ULL; /* -0.5 */
+    expect.cp1[14] = 0x4008000000000000ULL; /* 3.0 */
+    expect.cp1[15] = 0x3fe8000000000000ULL; /* 0.75 */
+    expect.cp1[16] = 0x3fe0000000000000ULL; /* 0.5 */
+    expect.cp1[17] = 0xc008000000000000ULL; /* -3.0 */
+    expect.cp1[18] = 0x3fe8000000000000ULL; /* 0.75 */
+    run_asm_test("cp1_arith", block, sizeof(block)/4, &init, &expect);
+}
+END_TEST
+
 START_TEST(test_complex_control_flow)
 {
     /* Loop with branches, delay slots and a dynamic jump back inside the block */
@@ -703,6 +746,7 @@ Suite *create_suite(void)
     tcase_add_test(tc_core, test_branch_likely);
     tcase_add_test(tc_core, test_cp0_moves);
     tcase_add_test(tc_core, test_cp1_moves);
+    tcase_add_test(tc_core, test_cp1_arith);
     tcase_add_test(tc_core, test_complex_control_flow);
     suite_add_tcase(s, tc_core);
     return s;


### PR DESCRIPTION
## Summary
- decode fd from bits 10..6 in emit_simple_instr
- use proper fs/ft/fd mapping for COP1 arithmetic instructions
- adjust single-precision and double-precision cases accordingly

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `./mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6840d6fd6698832bba96221641d9eff1