### PR TITLE
Improve floating-point conversion test

### DIFF
--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -128,6 +128,16 @@ Memory access instructions call the core memory subsystem via imported callbacks
 | NEG_S |
 | SUB_D |
 | SUB_S |
+| CVT_D_S |
+| CVT_D_W |
+| CVT_D_L |
+| CVT_S_D |
+| CVT_S_W |
+| CVT_S_L |
+| CVT_W_S |
+| CVT_W_D |
+| CVT_L_S |
+| CVT_L_D |
 
 ## Not yet implemented
 
@@ -141,16 +151,6 @@ Memory access instructions call the core memory subsystem via imported callbacks
 | CFC2 |
 | CTC1 |
 | CTC2 |
-| CVT_D_L |
-| CVT_D_S |
-| CVT_D_W |
-| CVT_L_D |
-| CVT_L_S |
-| CVT_S_D |
-| CVT_S_L |
-| CVT_S_W |
-| CVT_W_D |
-| CVT_W_S |
 | C_EQ_D |
 | C_EQ_S |
 | C_F_D |

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -1255,6 +1255,52 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        (size_t)CP1_SIMPLE_OFFSET(fd),
                        (size_t)CP1_SIMPLE_OFFSET(fs));
                 break;
+            case 0x21:
+                append(buf, size,
+                       "    ;; cvt.d.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f64.promote_f32\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x24:
+                append(buf, size,
+                       "    ;; cvt.w.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    i32.trunc_f32_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x25:
+                append(buf, size,
+                       "    ;; cvt.l.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    i64.trunc_f32_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
             default:
                 append(buf, size,
                        "    ;; unsupported COP1 fmt %u funct %u\n", sub, funct);
@@ -1388,6 +1434,130 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        "    i64.load\n"
                        "    f64.reinterpret_i64\n"
                        "    f64.neg\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x20:
+                append(buf, size,
+                       "    ;; cvt.s.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f32.demote_f64\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x24:
+                append(buf, size,
+                       "    ;; cvt.w.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    i32.trunc_f64_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x25:
+                append(buf, size,
+                       "    ;; cvt.l.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    i64.trunc_f64_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            default:
+                append(buf, size,
+                       "    ;; unsupported COP1 fmt %u funct %u\n", sub, funct);
+                break;
+            }
+            break; }
+        case 0x14: {
+            uint32_t fs = (inst >> 11) & 0x1f;
+            switch (funct) {
+            case 0x20:
+                append(buf, size,
+                       "    ;; cvt.s.w f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.convert_i32_s\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x21:
+                append(buf, size,
+                       "    ;; cvt.d.w f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f64.convert_i32_s\n"
+                       "    i64.reinterpret_f64\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            default:
+                append(buf, size,
+                       "    ;; unsupported COP1 fmt %u funct %u\n", sub, funct);
+                break;
+            }
+            break; }
+        case 0x15: {
+            uint32_t fs = (inst >> 11) & 0x1f;
+            switch (funct) {
+            case 0x20:
+                append(buf, size,
+                       "    ;; cvt.s.l f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f32.convert_i64_s\n"
+                       "    i32.reinterpret_f32\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x21:
+                append(buf, size,
+                       "    ;; cvt.d.l f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.convert_i64_s\n"
                        "    i64.reinterpret_f64\n"
                        "    i64.store\n",
                        fd, fs,

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -7,6 +7,20 @@
 #include "device/r4300/wasm_dynarec/wasm_dynarec.h"
 #include "device/memory/memory.h"
 
+#define ENCODE_COP1(fmt, ft, fs, fd, func) \
+    ((0x11u << 26) | ((fmt) << 21) | ((ft) << 16) | ((fs) << 11) | ((fd) << 6) | (func))
+
+#define CVT_D_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x21)
+#define CVT_S_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x20)
+#define CVT_W_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x24)
+#define CVT_W_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x24)
+#define CVT_L_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x25)
+#define CVT_L_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x25)
+#define CVT_S_W(fd, fs) ENCODE_COP1(0x14, 0, fs, fd, 0x20)
+#define CVT_D_W(fd, fs) ENCODE_COP1(0x14, 0, fs, fd, 0x21)
+#define CVT_S_L(fd, fs) ENCODE_COP1(0x15, 0, fs, fd, 0x20)
+#define CVT_D_L(fd, fs) ENCODE_COP1(0x15, 0, fs, fd, 0x21)
+
 /* minimal stubs to satisfy the dynarec build */
 void DebugMessage(int level, const char *fmt, ...) {}
 uint32_t *fast_mem_access(struct r4300_core *r4300, uint32_t address) { return NULL; }
@@ -170,7 +184,7 @@ START_TEST(test_opcode_scenarios)
         0x00431822
     };
     memset(&init_state, 0, sizeof(init_state));
-    memset(&expect_state, 0, sizeof(expect_state));
+    memcpy(&expect_state, &init_state, sizeof(expect_state));
     expect_state.hot.regs[2] = 8;
     expect_state.hot.regs[3] = 3;
     run_asm_test("arith", arith_block, sizeof(arith_block)/4, &init_state, &expect_state);
@@ -860,6 +874,43 @@ START_TEST(test_complex_control_flow)
 }
 END_TEST
 
+START_TEST(test_fp_conversions)
+{
+    const uint32_t block[] = {
+        CVT_D_S(2, 0),
+        CVT_S_D(3, 2),
+        CVT_W_S(4, 0),
+        CVT_W_D(5, 2),
+        CVT_L_S(6, 0),
+        CVT_L_D(7, 2),
+        CVT_S_W(8, 4),
+        CVT_S_L(9, 6),
+        CVT_D_W(10, 4),
+        CVT_D_L(11, 6),
+        0x00000000
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    {
+        float val = 1.5f;
+        memcpy(&init_state.cp1[0], &val, sizeof(val));
+    }
+    memset(&expect_state, 0, sizeof(expect_state));
+    expect_state.cp1[0]  = init_state.cp1[0];
+    expect_state.cp1[1]  = 0;
+    expect_state.cp1[2]  = 0x3ff8000000000000ULL; /* double 1.5 */
+    expect_state.cp1[3]  = init_state.cp1[0];    /* back to 1.5f */
+    expect_state.cp1[4]  = 0x0000000000000001ULL; /* int 1 */
+    expect_state.cp1[5]  = 0x0000000000000001ULL; /* int 1 */
+    expect_state.cp1[6]  = 0x0000000000000001ULL; /* long 1 */
+    expect_state.cp1[7]  = 0x0000000000000001ULL; /* long 1 */
+    expect_state.cp1[8]  = 0x000000003f800000ULL; /* float 1.0 */
+    expect_state.cp1[9]  = 0x000000003f800000ULL; /* float 1.0 */
+    expect_state.cp1[10] = 0x3ff0000000000000ULL; /* double 1.0 */
+    expect_state.cp1[11] = 0x3ff0000000000000ULL; /* double 1.0 */
+    run_asm_test("fp_conv", block, sizeof(block)/4, &init_state, &expect_state);
+}
+END_TEST
+
 Suite *create_suite(void)
 {
     Suite *s = suite_create("WebAssembly Dynarec");
@@ -878,6 +929,7 @@ Suite *create_suite(void)
     tcase_add_test(tc_core, test_shift_64);
     tcase_add_test(tc_core, test_muldiv_64);
     tcase_add_test(tc_core, test_ldl_ldr);
+    tcase_add_test(tc_core, test_fp_conversions);
     tcase_add_test(tc_core, test_complex_control_flow);
     suite_add_tcase(s, tc_core);
     return s;


### PR DESCRIPTION
## Summary
- exercise the floating point conversion opcodes with non-zero input
- verify all resulting FPR states in the unit test

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `./mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`


------
https://chatgpt.com/codex/tasks/task_e_684198e5a884832b900e591a57b87d50