### PR TITLE
Add branch likely opcode support

### DIFF
--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -26,6 +26,10 @@ Memory access instructions call the core memory subsystem via imported callbacks
 | BLTZAL |
 | BNE |
 | BNEL |
+| BC1F |
+| BC1FL |
+| BC1T |
+| BC1TL |
 | BREAK |
 | CACHE |
 | DADD |

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -3,6 +3,7 @@
 #include "api/callbacks.h"
 #include "device/r4300/r4300_core.h"
 #include "device/r4300/new_dynarec/new_dynarec.h"
+#include "device/r4300/fpu.h"
 #include "wasm3.h"
 #include <unistd.h>
 #include <stdlib.h>
@@ -17,6 +18,7 @@
 #define CP0_OFFSET(r) (offsetof(struct new_dynarec_hot_state, cp0_regs) + (r) * sizeof(uint32_t))
 #define CP1_SIMPLE_OFFSET(r) (offsetof(struct new_dynarec_hot_state, cp1_regs_simple) + (r) * sizeof(float *))
 #define CP1_DOUBLE_OFFSET(r) (offsetof(struct new_dynarec_hot_state, cp1_regs_double) + (r) * sizeof(double *))
+#define CP1_FCR31_OFFSET offsetof(struct new_dynarec_hot_state, cp1_fcr31)
 
 struct wasm_dynarec_block
 {
@@ -2313,8 +2315,14 @@ void wasm_dynarec_recompile_block(struct r4300_core *r4300, const uint32_t *iw, 
 
             const char *cond = NULL;
             switch (rtcode & ~0x10) {
-            case 0x00: cond = "lt_s"; break; /* BLTZ, BLTZAL */
-            case 0x01: cond = "ge_s"; break; /* BGEZ, BGEZAL */
+            case 0x00: /* BLTZ/BLTZAL */
+            case 0x02: /* BLTZL/BLTZALL */
+                cond = "lt_s";
+                break;
+            case 0x01: /* BGEZ/BGEZAL */
+            case 0x03: /* BGEZL/BGEZALL */
+                cond = "ge_s";
+                break;
             default:
                 append(&block->wat, &block->wat_size,
                        "    ;; unsupported REGIMM %02x\n", rtcode);
@@ -2371,6 +2379,59 @@ void wasm_dynarec_recompile_block(struct r4300_core *r4300, const uint32_t *iw, 
                     if (!known) targets[target_count++] = fallthrough;
                 }
                 i++;
+            }
+        }
+            break;
+
+        case 0x11: /* COP1 */
+        {
+            if (rs == 0x08) {
+                uint32_t rtcode = rt & 0x3;
+                uint32_t target = (address + (i + 1) * 4) + ((int16_t)imm << 2);
+                uint32_t fallthrough = address + (i + 2) * 4;
+                uint32_t delay = (i + 1 < count) ? iw[i + 1] : 0;
+
+                int likely = (rtcode & 2) != 0;
+                int cond = (rtcode & 1) != 0;
+
+                append(&block->wat, &block->wat_size,
+                       "    ;; bc1%s%s\n",
+                       cond ? "t" : "f",
+                       likely ? "l" : "");
+
+                if (!likely)
+                    emit_simple_instr(&block->wat, &block->wat_size, delay);
+
+                append(&block->wat, &block->wat_size,
+                       "    local.get $base i32.load offset=%zu\n"
+                       "    i32.const %u\n"
+                       "    i32.and\n"
+                       "    i32.const 0\n"
+                       "    i32.%s\n",
+                       (size_t)CP1_FCR31_OFFSET,
+                       FCR31_CMP_BIT,
+                       cond ? "ne" : "eq");
+                append(&block->wat, &block->wat_size, "    if\n");
+                if (likely)
+                    emit_simple_instr(&block->wat, &block->wat_size, delay);
+                append(&block->wat, &block->wat_size,
+                       "      local.get $base\n      call $block_%08x\n    else\n      local.get $base\n      call $block_%08x\n    end\n",
+                       target, fallthrough);
+                if (target_count < 32) {
+                    int known = 0;
+                    for (size_t ti = 0; ti < target_count; ++ti)
+                        if (targets[ti] == target) { known = 1; break; }
+                    if (!known) targets[target_count++] = target;
+                }
+                if (target_count < 32) {
+                    int known = 0;
+                    for (size_t ti = 0; ti < target_count; ++ti)
+                        if (targets[ti] == fallthrough) { known = 1; break; }
+                    if (!known) targets[target_count++] = fallthrough;
+                }
+                i++;
+            } else {
+                emit_simple_instr(&block->wat, &block->wat_size, inst);
             }
         }
             break;

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -6,6 +6,7 @@
 #include "device/r4300/r4300_core.h"
 #include "device/r4300/wasm_dynarec/wasm_dynarec.h"
 #include "device/memory/memory.h"
+#include "device/r4300/fpu.h"
 
 #define ENCODE_COP1(fmt, ft, fs, fd, func) \
     ((0x11u << 26) | ((fmt) << 21) | ((ft) << 16) | ((fs) << 11) | ((fd) << 6) | (func))
@@ -615,6 +616,100 @@ START_TEST(test_branch_likely)
     expect_state.hot.regs[9]  = 5;                      /* t1 */
     expect_state.hot.regs[31] = 0xffffffff8000000cULL;  /* ra */
     run_asm_test("bgezal_link", bgezal_block, sizeof(bgezal_block)/4, &init_state, &expect_state);
+
+    /* BLTZL - branch taken executes delay slot */
+    const uint32_t bltzl_taken_block[] = {
+        0x2008ffff, /* addi t0, zero, -1 */
+        0x05020002, /* bltzl t0, 2 */
+        0x20090005, /* addi t1, zero, 5 (delay slot) */
+        0x20090006, /* addi t1, zero, 6 (skipped) */
+        0x20090007, /* addi t1, zero, 7 (target) */
+        0x00000000  /* nop */
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    expect_state.hot.regs[8] = (uint64_t)-1; /* t0 */
+    expect_state.hot.regs[9] = 7;            /* t1 */
+    run_asm_test("bltzl_taken", bltzl_taken_block,
+                 sizeof(bltzl_taken_block)/4, &init_state, &expect_state);
+
+    /* BGEZALL - branch taken updates link register and executes delay slot */
+    const uint32_t bgezall_block[] = {
+        0x20080000, /* addi t0, zero, 0 */
+        0x05130002, /* bgezall t0, 2 */
+        0x20090005, /* addi t1, zero, 5 (delay slot) */
+        0x20090006, /* addi t1, zero, 6 (skipped) */
+        0x20090007, /* addi t1, zero, 7 (target) */
+        0x00000000  /* nop */
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    expect_state.hot.regs[8]  = 0;                       /* t0 */
+    expect_state.hot.regs[9]  = 7;                       /* t1 */
+    expect_state.hot.regs[31] = 0xffffffff8000000cULL;   /* ra */
+    run_asm_test("bgezall_link", bgezall_block, sizeof(bgezall_block)/4,
+                 &init_state, &expect_state);
+
+    /* BC1F - branch not taken executes delay slot */
+    const uint32_t bc1f_block[] = {
+        0x45000002, /* bc1f 2 */
+        0x20080005, /* addi t0, zero, 5 (delay slot) */
+        0x00000000, /* nop */
+        0x00000000  /* nop target */
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    init_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.regs[8] = 5;
+    run_asm_test("bc1f_skip", bc1f_block, sizeof(bc1f_block)/4,
+                 &init_state, &expect_state);
+
+    /* BC1T - branch taken executes delay slot */
+    const uint32_t bc1t_block[] = {
+        0x45010002, /* bc1t 2 */
+        0x20080005, /* addi t0, zero, 5 (delay slot) */
+        0x20080006, /* addi t0, zero, 6 (skipped) */
+        0x20080007, /* addi t0, zero, 7 (target) */
+        0x00000000
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    init_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.regs[8] = 7;
+    run_asm_test("bc1t_taken", bc1t_block, sizeof(bc1t_block)/4,
+                 &init_state, &expect_state);
+
+    /* BC1FL - branch not taken skips delay slot */
+    const uint32_t bc1fl_block[] = {
+        0x45020002, /* bc1fl 2 */
+        0x20080005, /* addi t0, zero, 5 (delay slot) */
+        0x00000000, /* nop */
+        0x00000000  /* nop target */
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    init_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    run_asm_test("bc1fl_skip", bc1fl_block, sizeof(bc1fl_block)/4,
+                 &init_state, &expect_state);
+
+    /* BC1TL - branch taken updates delay slot and jumps */
+    const uint32_t bc1tl_block[] = {
+        0x45030002, /* bc1tl 2 */
+        0x20080005, /* addi t0, zero, 5 (delay slot) */
+        0x20080006, /* addi t0, zero, 6 (skipped) */
+        0x20080007, /* addi t0, zero, 7 (target) */
+        0x00000000
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    memset(&expect_state, 0, sizeof(expect_state));
+    init_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.cp1_fcr31 = FCR31_CMP_BIT;
+    expect_state.hot.regs[8] = 7;
+    run_asm_test("bc1tl_taken", bc1tl_block, sizeof(bc1tl_block)/4,
+                 &init_state, &expect_state);
 
 }
 END_TEST


### PR DESCRIPTION
## Summary
- implement REGIMM branch likely variants in the wasm dynarec
- extend wasm dynarec tests with taken BLTZL and BGEZALL cases
- implement BC1F, BC1T, BC1FL and BC1TL opcodes in wasm dynarec
- update opcode coverage docs
- add tests for all BC1* branch variants

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6841a062d4a8832b954e5fde55abab5e