### PR TITLE
Implement ROUND and TRUNC opcodes in wasm dynarec

### DIFF
--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -151,6 +151,14 @@ Memory access instructions call the core memory subsystem via imported callbacks
 | FLOOR_L_S |
 | FLOOR_W_D |
 | FLOOR_W_S |
+| ROUND_L_D |
+| ROUND_L_S |
+| ROUND_W_D |
+| ROUND_W_S |
+| TRUNC_L_D |
+| TRUNC_L_S |
+| TRUNC_W_D |
+| TRUNC_W_S |
 
 ## Not yet implemented
 
@@ -202,18 +210,10 @@ Memory access instructions call the core memory subsystem via imported callbacks
 | NI |
 | RESERVED |
 | RESERVED_COP2 |
-| ROUND_L_D |
-| ROUND_L_S |
-| ROUND_W_D |
-| ROUND_W_S |
 | SQRT_D |
 | SQRT_S |
 | TLBP |
 | TLBR |
 | TLBWI |
 | TLBWR |
-| TRUNC_L_D |
-| TRUNC_L_S |
-| TRUNC_W_D |
-| TRUNC_W_S |
 

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -1257,6 +1257,38 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        (size_t)CP1_SIMPLE_OFFSET(fd),
                        (size_t)CP1_SIMPLE_OFFSET(fs));
                 break;
+            case 0x08:
+                append(buf, size,
+                       "    ;; round.l.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.nearest\n"
+                       "    i64.trunc_f32_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x09:
+                append(buf, size,
+                       "    ;; trunc.l.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.trunc\n"
+                       "    i64.trunc_f32_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
             case 0x0a:
                 append(buf, size,
                        "    ;; ceil.l.s f%u, f%u\n"
@@ -1287,6 +1319,38 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        "    i64.store\n",
                        fd, fs,
                        (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x0c:
+                append(buf, size,
+                       "    ;; round.w.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.nearest\n"
+                       "    i32.trunc_f32_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_SIMPLE_OFFSET(fs));
+                break;
+            case 0x0d:
+                append(buf, size,
+                       "    ;; trunc.w.s f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i32.load\n"
+                       "    f32.reinterpret_i32\n"
+                       "    f32.trunc\n"
+                       "    i32.trunc_f32_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
                        (size_t)CP1_SIMPLE_OFFSET(fs));
                 break;
             case 0x0e:
@@ -1506,6 +1570,38 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        (size_t)CP1_DOUBLE_OFFSET(fd),
                        (size_t)CP1_DOUBLE_OFFSET(fs));
                 break;
+            case 0x08:
+                append(buf, size,
+                       "    ;; round.l.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.nearest\n"
+                       "    i64.trunc_f64_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x09:
+                append(buf, size,
+                       "    ;; trunc.l.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.trunc\n"
+                       "    i64.trunc_f64_s\n"
+                       "    i64.store\n",
+                       fd, fs,
+                       (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
             case 0x0a:
                 append(buf, size,
                        "    ;; ceil.l.d f%u, f%u\n"
@@ -1536,6 +1632,38 @@ static void emit_simple_instr(char **buf, size_t *size, uint32_t inst)
                        "    i64.store\n",
                        fd, fs,
                        (size_t)CP1_DOUBLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x0c:
+                append(buf, size,
+                       "    ;; round.w.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.nearest\n"
+                       "    i32.trunc_f64_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
+                       (size_t)CP1_DOUBLE_OFFSET(fs));
+                break;
+            case 0x0d:
+                append(buf, size,
+                       "    ;; trunc.w.d f%u, f%u\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    local.get $base i64.load offset=%zu\n"
+                       "    i32.wrap_i64\n"
+                       "    i64.load\n"
+                       "    f64.reinterpret_i64\n"
+                       "    f64.trunc\n"
+                       "    i32.trunc_f64_s\n"
+                       "    i32.store\n",
+                       fd, fs,
+                       (size_t)CP1_SIMPLE_OFFSET(fd),
                        (size_t)CP1_DOUBLE_OFFSET(fs));
                 break;
             case 0x0e:

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -29,6 +29,14 @@
 #define FLOOR_L_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x0b)
 #define FLOOR_W_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x0f)
 #define FLOOR_W_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x0f)
+#define ROUND_L_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x08)
+#define ROUND_L_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x08)
+#define TRUNC_L_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x09)
+#define TRUNC_L_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x09)
+#define ROUND_W_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x0c)
+#define ROUND_W_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x0c)
+#define TRUNC_W_S(fd, fs) ENCODE_COP1(0x10, 0, fs, fd, 0x0d)
+#define TRUNC_W_D(fd, fs) ENCODE_COP1(0x11, 0, fs, fd, 0x0d)
 
 /* minimal stubs to satisfy the dynarec build */
 void DebugMessage(int level, const char *fmt, ...) {}
@@ -1072,6 +1080,64 @@ START_TEST(test_fp_floor)
 }
 END_TEST
 
+START_TEST(test_fp_round)
+{
+    const uint32_t block[] = {
+        ROUND_L_S(6, 0),
+        ROUND_L_D(7, 2),
+        ROUND_W_S(8, 0),
+        ROUND_W_D(9, 2),
+        0x00000000
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    {
+        float val_s = 1.6f;
+        memcpy(&init_state.cp1[0], &val_s, sizeof(val_s));
+    }
+    {
+        double val_d = 1.6;
+        memcpy(&init_state.cp1[2], &val_d, sizeof(val_d));
+    }
+    memset(&expect_state, 0, sizeof(expect_state));
+    expect_state.cp1[0] = init_state.cp1[0];
+    expect_state.cp1[2] = init_state.cp1[2];
+    expect_state.cp1[6] = 0x0000000000000002ULL; /* round.l.s result */
+    expect_state.cp1[7] = 0x0000000000000002ULL; /* round.l.d result */
+    expect_state.cp1[8] = 0x0000000000000002ULL; /* round.w.s result */
+    expect_state.cp1[9] = 0x0000000000000002ULL; /* round.w.d result */
+    run_asm_test("fp_round", block, sizeof(block)/4, &init_state, &expect_state);
+}
+END_TEST
+
+START_TEST(test_fp_trunc)
+{
+    const uint32_t block[] = {
+        TRUNC_L_S(6, 0),
+        TRUNC_L_D(7, 2),
+        TRUNC_W_S(8, 0),
+        TRUNC_W_D(9, 2),
+        0x00000000
+    };
+    memset(&init_state, 0, sizeof(init_state));
+    {
+        float val_s = -1.8f;
+        memcpy(&init_state.cp1[0], &val_s, sizeof(val_s));
+    }
+    {
+        double val_d = -1.8;
+        memcpy(&init_state.cp1[2], &val_d, sizeof(val_d));
+    }
+    memset(&expect_state, 0, sizeof(expect_state));
+    expect_state.cp1[0] = init_state.cp1[0];
+    expect_state.cp1[2] = init_state.cp1[2];
+    expect_state.cp1[6] = 0xffffffffffffffffULL; /* trunc.l.s result */
+    expect_state.cp1[7] = 0xffffffffffffffffULL; /* trunc.l.d result */
+    expect_state.cp1[8] = 0x00000000ffffffffULL; /* trunc.w.s result */
+    expect_state.cp1[9] = 0x00000000ffffffffULL; /* trunc.w.d result */
+    run_asm_test("fp_trunc", block, sizeof(block)/4, &init_state, &expect_state);
+}
+END_TEST
+
 Suite *create_suite(void)
 {
     Suite *s = suite_create("WebAssembly Dynarec");
@@ -1093,6 +1159,8 @@ Suite *create_suite(void)
     tcase_add_test(tc_core, test_fp_conversions);
     tcase_add_test(tc_core, test_fp_ceil);
     tcase_add_test(tc_core, test_fp_floor);
+    tcase_add_test(tc_core, test_fp_round);
+    tcase_add_test(tc_core, test_fp_trunc);
     tcase_add_test(tc_core, test_complex_control_flow);
     suite_add_tcase(s, tc_core);
     return s;


### PR DESCRIPTION
## Summary
- add ROUND/ TRUNC macros and tests in wasm dynarec unit tests
- implement ROUND_* and TRUNC_* instructions in the wasm dynarec
- document the newly implemented opcodes

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `./mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6841aadb6e6c832ba8e5e4eeb975f93d