### PR TITLE
Update wasm dynarec docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ dispatcher is invoked with that static address instead.
 Recent updates added handling for less common instructions such as `LDL/LDR`,
 system calls (`SYSCALL`, `BREAK`, `SYNC`), and cache management opcodes.
 `CACHE` and `PREF` are currently treated as no-ops.
-Floating point and coprocessor instructions remain unimplemented. Execution of
-the generated code is not yet implemented
-so the emulator continues to fall back to the cached interpreter.
 A table showing current opcode coverage can be found in [docs/wasm_dynarec_opcode_coverage.md](docs/wasm_dynarec_opcode_coverage.md).
 
  An accompanying unit test in `mupen64plus-core/test/wasm_dynarec` demonstrates
@@ -61,6 +58,7 @@ A table showing current opcode coverage can be found in [docs/wasm_dynarec_opcod
 `run_generated_wasm.js` that instantiates this module, initializes a minimal
 CPU state and executes the exported block using the browser-style WebAssembly
 API.
+When compiled with Emscripten the `wasm_dynarec_exec` function now calls a JavaScript helper. This helper uses `Module['wabt']` or `Binaryen` to compile the generated WAT into a binary module before running it. The runtime must provide one of these objects so execution can proceed. Memory accesses from JavaScript use helper functions exported with `EMSCRIPTEN_KEEPALIVE`.
 
 Additional unit tests exercise signed multiply/divide edge cases to ensure the
 HI and LO registers receive correctly sign-extended results even when operands

--- a/docs/wasm_dynarec_opcode_coverage.md
+++ b/docs/wasm_dynarec_opcode_coverage.md
@@ -3,6 +3,7 @@
 This document tracks which MIPS instructions are currently handled by the experimental WebAssembly dynamic recompiler. Instruction names correspond to those used in [`mips_instructions.def`](../mupen64plus-core/src/device/r4300/mips_instructions.def). Some opcodes such as `ADDIU` and `DADDIU` are implemented via the `ADDI` and `DADDI` cases.
 
 Memory access instructions call the core memory subsystem via imported callbacks rather than using raw WebAssembly loads and stores.
+ When running under Emscripten these callbacks are exported with `EMSCRIPTEN_KEEPALIVE` so JavaScript can invoke them.
 
 ## Implemented opcodes
 


### PR DESCRIPTION
## Summary
- remove outdated note about generated code not being executed
- document JavaScript dispatch for wasm dynarec under Emscripten
- explain runtime requirements for WAT compilation
- mention EMSCRIPTEN_KEEPALIVE memory helpers

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6842160e5da8832bbf54aa5a0bb3787e