### PR TITLE
Add Emscripten build notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ CPU state and executes the exported block using the browser-style WebAssembly
 API.
 When compiled with Emscripten the `wasm_dynarec_exec` function now calls a JavaScript helper. This helper uses `Module['wabt']` or `Binaryen` to compile the generated WAT into a binary module before running it. The runtime must provide one of these objects so execution can proceed. Memory accesses from JavaScript use helper functions exported with `EMSCRIPTEN_KEEPALIVE`.
 
+For detailed steps on compiling the core for the web see
+[docs/emscripten_build.md](docs/emscripten_build.md).
+
 Additional unit tests exercise signed multiply/divide edge cases to ensure the
 HI and LO registers receive correctly sign-extended results even when operands
 are negative or the product overflows 32 bits.

--- a/docs/emscripten_build.md
+++ b/docs/emscripten_build.md
@@ -1,0 +1,44 @@
+# Building with Emscripten
+
+This guide explains how to compile the libretro core for use in a browser.
+
+## Build steps
+
+Ensure the Emscripten SDK is installed and `emcc` is in your `PATH`. From the
+repository root run:
+
+```
+make platform=emscripten
+```
+
+The build will generate `mupen64plus_next_libretro_emscripten.bc`. Convert the
+bitcode to a runnable module with `emcc`:
+
+```
+emcc mupen64plus_next_libretro_emscripten.bc -O2 -s WASM=1 -s MODULARIZE=1 -s EXPORT_NAME="Module" -o mupen64plus_next.js
+```
+
+Include either `wabt.js` or `binaryen.js` in your page so the runtime provides
+`Module['wabt']` or a global `Binaryen` object. `wasm_dynarec_exec` uses these
+helpers to compile generated WebAssembly text on the fly.
+
+The build exports memory callbacks via `EMSCRIPTEN_KEEPALIVE` so they remain
+accessible from JavaScript. These functions appear on the `Module` object as
+`_wasm_dynarec_dispatch_import`, `_wasm_dynarec_read_word`,
+`_wasm_dynarec_read_dword`, `_wasm_dynarec_write_word` and
+`_wasm_dynarec_write_dword`.
+
+## Example
+
+```html
+<script src="wabt.js"></script> <!-- or binaryen.js -->
+<script src="mupen64plus_next.js"></script>
+<script>
+Module.onRuntimeInitialized = function () {
+  // Load a ROM file if desired using the Emscripten FS, then start the core.
+  Module.ccall('retro_init');
+  // Example: Module.ccall('retro_run');
+  // Memory helpers are available as Module._wasm_dynarec_read_word(), etc.
+};
+</script>
+```


### PR DESCRIPTION
## Summary
- document building the core with Emscripten
- link to the new build guide from README

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6842177e3acc832b8945d8b3246cf162