### PR TITLE
Fix stack pointer during WASM dynarec init

### DIFF
--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -2035,8 +2035,6 @@ void wasm_dynarec_init(struct r4300_core *r4300)
     g_blocks = NULL;
     g_blocks_count = 0;
 
-    memset(&r4300->new_dynarec_hot_state, 0,
-           sizeof(r4300->new_dynarec_hot_state));
 
 #ifdef NEW_DYNAREC
     r4300->new_dynarec_hot_state.pc =


### PR DESCRIPTION
## Summary
- avoid clearing CPU registers in `wasm_dynarec_init`

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_6849b022f560832ba995f86e1d201497