### PR TITLE
Fix cp0 state syncing for wasm dynarec

### DIFF
--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -626,6 +626,26 @@ EM_JS(void, wasm_dynarec_exec_js,
       Module['_wasm_dynarec_cp0_write'](base, reg, value);
       sync_from_heap();
     };
+    const tlbp_wrapper = function(base) {
+      sync_to_heap();
+      Module['_wasm_dynarec_tlbp'](base);
+      sync_from_heap();
+    };
+    const tlbr_wrapper = function(base) {
+      sync_to_heap();
+      Module['_wasm_dynarec_tlbr'](base);
+      sync_from_heap();
+    };
+    const tlbwi_wrapper = function(base) {
+      sync_to_heap();
+      Module['_wasm_dynarec_tlbwi'](base);
+      sync_from_heap();
+    };
+    const tlbwr_wrapper = function(base) {
+      sync_to_heap();
+      Module['_wasm_dynarec_tlbwr'](base);
+      sync_from_heap();
+    };
 
     const imports = {
       env: {
@@ -636,10 +656,10 @@ EM_JS(void, wasm_dynarec_exec_js,
         mem_write64: mem_write64_wrapper,
         cp0_read: cp0_read_wrapper,
         cp0_write: cp0_write_wrapper,
-        tlbp: Module['_wasm_dynarec_tlbp'],
-        tlbr: Module['_wasm_dynarec_tlbr'],
-        tlbwi: Module['_wasm_dynarec_tlbwi'],
-        tlbwr: Module['_wasm_dynarec_tlbwr']
+        tlbp: tlbp_wrapper,
+        tlbr: tlbr_wrapper,
+        tlbwi: tlbwi_wrapper,
+        tlbwr: tlbwr_wrapper
       }
     };
 

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -584,6 +584,28 @@ EM_JS(void, wasm_dynarec_exec_js,
       Module['_wasm_dynarec_dispatch_import'](base, a);
       sync_from_heap();
     };
+    const mem_read32_wrapper = function(base, addr) {
+      sync_to_heap();
+      const v = Module['_wasm_dynarec_read_word'](base, addr);
+      sync_from_heap();
+      return v;
+    };
+    const mem_read64_wrapper = function(base, addr) {
+      sync_to_heap();
+      const v = Module['_wasm_dynarec_read_dword'](base, addr);
+      sync_from_heap();
+      return v;
+    };
+    const mem_write32_wrapper = function(base, addr, value, mask) {
+      sync_to_heap();
+      Module['_wasm_dynarec_write_word'](base, addr, value, mask);
+      sync_from_heap();
+    };
+    const mem_write64_wrapper = function(base, addr, value, mask) {
+      sync_to_heap();
+      Module['_wasm_dynarec_write_dword'](base, addr, value, mask);
+      sync_from_heap();
+    };
     const cp0_read_wrapper = function(base, reg) {
       sync_to_heap();
       const v = Module['_wasm_dynarec_cp0_read'](base, reg);
@@ -599,10 +621,10 @@ EM_JS(void, wasm_dynarec_exec_js,
     const imports = {
       env: {
         wasm_dynarec_dispatch: dispatch_wrapper,
-        mem_read32: Module['_wasm_dynarec_read_word'],
-        mem_read64: Module['_wasm_dynarec_read_dword'],
-        mem_write32: Module['_wasm_dynarec_write_word'],
-        mem_write64: Module['_wasm_dynarec_write_dword'],
+        mem_read32: mem_read32_wrapper,
+        mem_read64: mem_read64_wrapper,
+        mem_write32: mem_write32_wrapper,
+        mem_write64: mem_write64_wrapper,
         cp0_read: cp0_read_wrapper,
         cp0_write: cp0_write_wrapper,
         tlbp: Module['_wasm_dynarec_tlbp'],

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -545,6 +545,9 @@ EM_JS(void, wasm_dynarec_exec_js,
   const heapU8 = HEAPU8;
   const heapDV = new DataView(HEAPU8.buffer);
   const CP1_BASE = 0x8000;
+  const CP1_PTR_SIZE = 32 * 8;
+  const CP1_REGION_START = cp1_simple_off;
+  const CP1_REGION_END = cp1_double_off + CP1_PTR_SIZE;
 
   if (!block) {
     let wasmBytes;
@@ -564,19 +567,25 @@ EM_JS(void, wasm_dynarec_exec_js,
 
     let tmpU8, tmpDV;
     const sync_to_heap = function() {
-      for (let i = 0; i < state_size; i++)
+      for (let i = 0; i < state_size; i++) {
+        if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
         heapU8[state_ptr + i] = tmpU8[i];
+      }
       for (let i = 0; i < 32; i++) {
         const v = tmpDV.getBigUint64(CP1_BASE + i * 8, true);
         heapDV.setBigUint64(cp1_ptr + i * 8, v, true);
       }
     };
     const sync_from_heap = function() {
-      for (let i = 0; i < state_size; i++)
+      for (let i = 0; i < state_size; i++) {
+        if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
         tmpU8[i] = heapU8[state_ptr + i];
+      }
       for (let i = 0; i < 32; i++) {
         const v = heapDV.getBigUint64(cp1_ptr + i * 8, true);
         tmpDV.setBigUint64(CP1_BASE + i * 8, v, true);
+        tmpDV.setBigUint64(cp1_simple_off + i * 8, BigInt(CP1_BASE + i * 8), true);
+        tmpDV.setBigUint64(cp1_double_off + i * 8, BigInt(CP1_BASE + i * 8), true);
       }
     };
     const dispatch_wrapper = function(base, a) {
@@ -660,8 +669,10 @@ EM_JS(void, wasm_dynarec_exec_js,
 
   entry(0);
 
-  for (let i = 0; i < state_size; i++)
+  for (let i = 0; i < state_size; i++) {
+    if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
     heapU8[state_ptr + i] = memU8[i];
+  }
 
   for (let i = 0; i < 32; i++) {
     const val = memDV.getBigUint64(CP1_BASE + i * 8, true);

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -535,7 +535,8 @@ static size_t get_remaining_count(uint32_t address)
 #ifdef __EMSCRIPTEN__
 EM_JS(void, wasm_dynarec_exec_js,
       (uint32_t addr, uintptr_t state_ptr, uintptr_t cp1_ptr, const char *wat,
-       size_t state_size, size_t cp1_simple_off, size_t cp1_double_off),
+       size_t state_size, size_t cp1_simple_off, size_t cp1_double_off,
+       size_t mmap_off, size_t mmap_size),
 {
   const watStr = UTF8ToString(wat);
   Module.wasmBlockCache = Module.wasmBlockCache || {};
@@ -548,6 +549,8 @@ EM_JS(void, wasm_dynarec_exec_js,
   const CP1_PTR_SIZE = 32 * 8;
   const CP1_REGION_START = cp1_simple_off;
   const CP1_REGION_END = cp1_double_off + CP1_PTR_SIZE;
+  const MMAP_REGION_START = mmap_off;
+  const MMAP_REGION_END = mmap_off + mmap_size;
 
   if (!block) {
     let wasmBytes;
@@ -568,7 +571,9 @@ EM_JS(void, wasm_dynarec_exec_js,
     let tmpU8, tmpDV;
     const sync_to_heap = function() {
       for (let i = 0; i < state_size; i++) {
-        if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
+        if ((i >= CP1_REGION_START && i < CP1_REGION_END) ||
+            (i >= MMAP_REGION_START && i < MMAP_REGION_END))
+          continue;
         heapU8[state_ptr + i] = tmpU8[i];
       }
       for (let i = 0; i < 32; i++) {
@@ -578,7 +583,9 @@ EM_JS(void, wasm_dynarec_exec_js,
     };
     const sync_from_heap = function() {
       for (let i = 0; i < state_size; i++) {
-        if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
+        if ((i >= CP1_REGION_START && i < CP1_REGION_END) ||
+            (i >= MMAP_REGION_START && i < MMAP_REGION_END))
+          continue;
         tmpU8[i] = heapU8[state_ptr + i];
       }
       for (let i = 0; i < 32; i++) {
@@ -676,8 +683,12 @@ EM_JS(void, wasm_dynarec_exec_js,
     ({instance, memU8, memDV, entry} = block);
   }
 
-  for (let i = 0; i < state_size; i++)
+  for (let i = 0; i < state_size; i++) {
+    if ((i >= CP1_REGION_START && i < CP1_REGION_END) ||
+        (i >= MMAP_REGION_START && i < MMAP_REGION_END))
+      continue;
     memU8[i] = heapU8[state_ptr + i];
+  }
 
   // CP1_BASE declared above
   for (let i = 0; i < 32; i++) {
@@ -690,7 +701,9 @@ EM_JS(void, wasm_dynarec_exec_js,
   entry(0);
 
   for (let i = 0; i < state_size; i++) {
-    if (i >= CP1_REGION_START && i < CP1_REGION_END) continue;
+    if ((i >= CP1_REGION_START && i < CP1_REGION_END) ||
+        (i >= MMAP_REGION_START && i < MMAP_REGION_END))
+      continue;
     heapU8[state_ptr + i] = memU8[i];
   }
 
@@ -2807,7 +2820,9 @@ void wasm_dynarec_exec(struct r4300_core *r4300, uint32_t address)
                          block->wat,
                          sizeof(struct new_dynarec_hot_state),
                          offsetof(struct new_dynarec_hot_state, cp1_regs_simple),
-                         offsetof(struct new_dynarec_hot_state, cp1_regs_double));
+                         offsetof(struct new_dynarec_hot_state, cp1_regs_double),
+                         offsetof(struct new_dynarec_hot_state, memory_map),
+                         sizeof(((struct new_dynarec_hot_state*)0)->memory_map));
 
     if (block->idle && r4300->new_dynarec_hot_state.cycle_count < 0) {
         r4300->new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG] -=

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -563,20 +563,37 @@ EM_JS(void, wasm_dynarec_exec_js,
     }
 
     let tmpU8, tmpDV;
-    const dispatch_wrapper = function(base, a) {
+    const sync_to_heap = function() {
       for (let i = 0; i < state_size; i++)
         heapU8[state_ptr + i] = tmpU8[i];
       for (let i = 0; i < 32; i++) {
         const v = tmpDV.getBigUint64(CP1_BASE + i * 8, true);
         heapDV.setBigUint64(cp1_ptr + i * 8, v, true);
       }
-      Module['_wasm_dynarec_dispatch_import'](base, a);
+    };
+    const sync_from_heap = function() {
       for (let i = 0; i < state_size; i++)
         tmpU8[i] = heapU8[state_ptr + i];
       for (let i = 0; i < 32; i++) {
         const v = heapDV.getBigUint64(cp1_ptr + i * 8, true);
         tmpDV.setBigUint64(CP1_BASE + i * 8, v, true);
       }
+    };
+    const dispatch_wrapper = function(base, a) {
+      sync_to_heap();
+      Module['_wasm_dynarec_dispatch_import'](base, a);
+      sync_from_heap();
+    };
+    const cp0_read_wrapper = function(base, reg) {
+      sync_to_heap();
+      const v = Module['_wasm_dynarec_cp0_read'](base, reg);
+      sync_from_heap();
+      return v;
+    };
+    const cp0_write_wrapper = function(base, reg, value) {
+      sync_to_heap();
+      Module['_wasm_dynarec_cp0_write'](base, reg, value);
+      sync_from_heap();
     };
 
     const imports = {
@@ -586,8 +603,8 @@ EM_JS(void, wasm_dynarec_exec_js,
         mem_read64: Module['_wasm_dynarec_read_dword'],
         mem_write32: Module['_wasm_dynarec_write_word'],
         mem_write64: Module['_wasm_dynarec_write_dword'],
-        cp0_read: Module['_wasm_dynarec_cp0_read'],
-        cp0_write: Module['_wasm_dynarec_cp0_write'],
+        cp0_read: cp0_read_wrapper,
+        cp0_write: cp0_write_wrapper,
         tlbp: Module['_wasm_dynarec_tlbp'],
         tlbr: Module['_wasm_dynarec_tlbr'],
         tlbwi: Module['_wasm_dynarec_tlbwi'],


### PR DESCRIPTION
## Summary
- fix cp0 read/write WebAssembly wrappers to sync hot state

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_684aad771b74832bbfa07fc406bad1fa