### PR TITLE
Switch wasm blocks to imported memory

### DIFF
--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -540,11 +540,22 @@ EM_JS(void, wasm_dynarec_exec_js,
   const watStr = UTF8ToString(wat);
   Module.wasmBlockCache = Module.wasmBlockCache || {};
   let block = Module.wasmBlockCache[addr];
-  let instance, memU8, memDV, entry;
+  let instance, entry;
 
   const heapU8 = HEAPU8;
   const heapDV = new DataView(HEAPU8.buffer);
   const CP1_BASE = 0x8000;
+
+  const totalPages = ((state_size + 0x8000 + 0x1000 + 65535) >>> 16);
+  if (!Module.wasmMemory) {
+    Module.wasmMemory = new WebAssembly.Memory({initial: totalPages});
+    Module.wasmMemoryU8 = new Uint8Array(Module.wasmMemory.buffer);
+    Module.wasmMemoryDV = new DataView(Module.wasmMemory.buffer);
+    for (let i = 0; i < 32; i++) {
+      Module.wasmMemoryDV.setBigUint64(cp1_simple_off + i * 8, BigInt(CP1_BASE + i * 8), true);
+      Module.wasmMemoryDV.setBigUint64(cp1_double_off + i * 8, BigInt(CP1_BASE + i * 8), true);
+    }
+  }
 
   if (!block) {
     let wasmBytes;
@@ -562,21 +573,8 @@ EM_JS(void, wasm_dynarec_exec_js,
       while(true) {}
     }
 
-    let tmpU8, tmpDV;
     const dispatch_wrapper = function(base, a) {
-      for (let i = 0; i < state_size; i++)
-        heapU8[state_ptr + i] = tmpU8[i];
-      for (let i = 0; i < 32; i++) {
-        const v = tmpDV.getBigUint64(CP1_BASE + i * 8, true);
-        heapDV.setBigUint64(cp1_ptr + i * 8, v, true);
-      }
       Module['_wasm_dynarec_dispatch_import'](base, a);
-      for (let i = 0; i < state_size; i++)
-        tmpU8[i] = heapU8[state_ptr + i];
-      for (let i = 0; i < 32; i++) {
-        const v = heapDV.getBigUint64(cp1_ptr + i * 8, true);
-        tmpDV.setBigUint64(CP1_BASE + i * 8, v, true);
-      }
     };
 
     const imports = {
@@ -591,43 +589,21 @@ EM_JS(void, wasm_dynarec_exec_js,
         tlbp: Module['_wasm_dynarec_tlbp'],
         tlbr: Module['_wasm_dynarec_tlbr'],
         tlbwi: Module['_wasm_dynarec_tlbwi'],
-        tlbwr: Module['_wasm_dynarec_tlbwr']
+        tlbwr: Module['_wasm_dynarec_tlbwr'],
+        memory: Module.wasmMemory
       }
     };
 
     instance = new WebAssembly.Instance(new WebAssembly.Module(wasmBytes), imports);
-    tmpU8 = new Uint8Array(instance.exports.memory.buffer);
-    tmpDV = new DataView(instance.exports.memory.buffer);
     entry = instance.exports.entry;
 
-    block = {instance, memU8: tmpU8, memDV: tmpDV, entry};
+    block = {instance, entry};
     Module.wasmBlockCache[addr] = block;
-    memU8 = tmpU8;
-    memDV = tmpDV;
   } else {
-    ({instance, memU8, memDV, entry} = block);
-  }
-
-  for (let i = 0; i < state_size; i++)
-    memU8[i] = heapU8[state_ptr + i];
-
-  // CP1_BASE declared above
-  for (let i = 0; i < 32; i++) {
-    const val = heapDV.getBigUint64(cp1_ptr + i * 8, true);
-    memDV.setBigUint64(CP1_BASE + i * 8, val, true);
-    memDV.setBigUint64(cp1_simple_off + i * 8, BigInt(CP1_BASE + i * 8), true);
-    memDV.setBigUint64(cp1_double_off + i * 8, BigInt(CP1_BASE + i * 8), true);
+    ({instance, entry} = block);
   }
 
   entry(0);
-
-  for (let i = 0; i < state_size; i++)
-    heapU8[state_ptr + i] = memU8[i];
-
-  for (let i = 0; i < 32; i++) {
-    const val = memDV.getBigUint64(CP1_BASE + i * 8, true);
-    heapDV.setBigUint64(cp1_ptr + i * 8, val, true);
-  }
 });
 #endif
 
@@ -2293,7 +2269,7 @@ void wasm_dynarec_recompile_block(struct r4300_core *r4300, const uint32_t *iw, 
            "  (import \"env\" \"tlbr\" (func $tlbr (param i32)))\n"
            "  (import \"env\" \"tlbwi\" (func $tlbwi (param i32)))\n"
            "  (import \"env\" \"tlbwr\" (func $tlbwr (param i32)))\n"
-           "  (memory %u)\n"
+           "  (import \"env\" \"memory\" (memory %u))\n"
            "  (func $block_%x (param $base i32) (local $t i64) (local $tmp i32)\n",
            block->mem_pages, address);
 
@@ -2697,7 +2673,6 @@ void wasm_dynarec_recompile_block(struct r4300_core *r4300, const uint32_t *iw, 
     }
 
     append(&block->wat, &block->wat_size,
-           "  (export \"memory\" (memory 0))\n"
            "  (export \"entry\" (func $block_%x))\n"
            ")\n",
            address);

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -549,7 +549,11 @@ EM_JS(void, wasm_dynarec_exec_js,
 
   const totalPages = ((state_size + 0x8000 + 0x1000 + 65535) >>> 16);
   if (!Module.wasmMemory) {
-    Module.wasmMemory = new WebAssembly.Memory({initial: totalPages});
+    Module.wasmMemory = new WebAssembly.Memory({
+      initial: totalPages,
+      maximum: totalPages,
+      shared: true
+    });
     Module.wasmMemoryU8 = new Uint8Array(Module.wasmMemory.buffer);
     Module.wasmMemoryDV = new DataView(Module.wasmMemory.buffer);
     for (let i = 0; i < 32; i++) {
@@ -561,11 +565,17 @@ EM_JS(void, wasm_dynarec_exec_js,
   if (!block) {
     let wasmBytes;
     if (Module['wabt']) {
-      const mod = Module['wabt'].parseWat('block.wat', watStr);
+      const mod = Module['wabt'].parseWat('block.wat', watStr, {
+        features: { threads: true }
+      });
       wasmBytes = mod.toBinary({}).buffer;
       mod.destroy();
     } else if (typeof Binaryen !== 'undefined') {
       const mod = Binaryen.parseText(watStr);
+      if (Binaryen._BinaryenModuleSetFeatures)
+        Binaryen._BinaryenModuleSetFeatures(mod,
+          Binaryen._BinaryenFeatureAtomics() |
+          Binaryen._BinaryenFeatureMutableGlobals());
       wasmBytes = mod.emitBinary();
       mod.dispose();
     } else {
@@ -2290,9 +2300,9 @@ void wasm_dynarec_recompile_block(struct r4300_core *r4300, const uint32_t *iw, 
            "  (import \"env\" \"tlbr\" (func $tlbr (param i32)))\n"
            "  (import \"env\" \"tlbwi\" (func $tlbwi (param i32)))\n"
            "  (import \"env\" \"tlbwr\" (func $tlbwr (param i32)))\n"
-           "  (import \"env\" \"memory\" (memory %u))\n"
+           "  (import \"env\" \"memory\" (memory %u %u shared))\n"
            "  (func $block_%x (param $base i32) (local $t i64) (local $tmp i32)\n",
-           block->mem_pages, address);
+           block->mem_pages, block->mem_pages, address);
 
     for (size_t i = 0; i < count; ++i) {
         uint32_t inst = iw[i];
@@ -2760,7 +2770,7 @@ void wasm_dynarec_exec(struct r4300_core *r4300, uint32_t address)
     fclose(f);
 
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "wat2wasm %s -o %s", wat_path, wasm_path);
+    snprintf(cmd, sizeof(cmd), "wat2wasm %s --enable-threads -o %s", wat_path, wasm_path);
     if (system(cmd) != 0)
         return;
 

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -541,7 +541,7 @@ EM_JS(void, wasm_dynarec_exec_js,
   const watStr = UTF8ToString(wat);
   Module.wasmBlockCache = Module.wasmBlockCache || {};
   let block = Module.wasmBlockCache[addr];
-  let instance, entry;
+  let instance, entry, memU8, memDV;
 
   const heapU8 = HEAPU8;
   const heapDV = new DataView(HEAPU8.buffer);
@@ -600,11 +600,31 @@ EM_JS(void, wasm_dynarec_exec_js,
 
     block = {instance, entry};
     Module.wasmBlockCache[addr] = block;
+    memU8 = Module.wasmMemoryU8;
+    memDV = Module.wasmMemoryDV;
   } else {
     ({instance, entry} = block);
+    memU8 = Module.wasmMemoryU8;
+    memDV = Module.wasmMemoryDV;
+  }
+
+  for (let i = 0; i < state_size; i++)
+    memU8[i] = heapU8[state_ptr + i];
+
+  for (let i = 0; i < 32; i++) {
+    const val = heapDV.getBigUint64(cp1_ptr + i * 8, true);
+    memDV.setBigUint64(CP1_BASE + i * 8, val, true);
   }
 
   entry(0);
+
+  for (let i = 0; i < state_size; i++)
+    heapU8[state_ptr + i] = memU8[i];
+
+  for (let i = 0; i < 32; i++) {
+    const val = memDV.getBigUint64(CP1_BASE + i * 8, true);
+    heapDV.setBigUint64(cp1_ptr + i * 8, val, true);
+  }
 });
 #endif
 

--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -12,6 +12,7 @@
 # include <emscripten/emscripten.h>
 #else
 #include "wasm3.h"
+#include "m3_env.h"
 #endif
 #include <unistd.h>
 #include <stdlib.h>
@@ -2755,6 +2756,9 @@ void wasm_dynarec_exec(struct r4300_core *r4300, uint32_t address)
 
     IM3Environment env = m3_NewEnvironment();
     IM3Runtime runtime = m3_NewRuntime(env, 64*1024, NULL);
+    runtime->memory.maxPages = block->mem_pages;
+    runtime->memory.pageSize = d_m3DefaultMemPageSize;
+    ResizeMemory(runtime, block->mem_pages);
     IM3Module module = NULL;
     M3Result m3res = m3_ParseModule(env, &module, wasm, wasm_size);
     if (!m3res) m3res = m3_LoadModule(runtime, module);

--- a/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
+++ b/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
@@ -39,11 +39,16 @@ const CP1_DOUBLE_OFFSET = parseOffset('offsetof_struct_new_dynarec_hot_state_cp1
 const CP1_REG_BASE = 0x8000;
 
 (async () => {
+  const module = await WebAssembly.compile(wasmBuffer);
+  const memImport = WebAssembly.Module.imports(module).find(i => i.kind === 'memory');
+  const pages = memImport ? memImport.minimum : 1;
+  const memory = new WebAssembly.Memory({ initial: pages });
   const env = {
     wasm_dynarec_dispatch: () => {},
+    memory,
   };
-  const mod = await WebAssembly.instantiate(wasmBuffer, { env });
-  const { memory, entry } = mod.instance.exports;
+  const { instance } = await WebAssembly.instantiate(module, { env });
+  const { entry } = instance.exports;
   const view = new DataView(memory.buffer);
 
   for (let i = 0; i < 32; i++) {

--- a/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
+++ b/mupen64plus-core/test/wasm_dynarec/run_generated_wasm.js
@@ -42,7 +42,11 @@ const CP1_REG_BASE = 0x8000;
   const module = await WebAssembly.compile(wasmBuffer);
   const memImport = WebAssembly.Module.imports(module).find(i => i.kind === 'memory');
   const pages = memImport ? memImport.minimum : 1;
-  const memory = new WebAssembly.Memory({ initial: pages });
+  const memory = new WebAssembly.Memory({
+    initial: pages,
+    maximum: memImport && memImport.maximum ? memImport.maximum : pages,
+    shared: memImport && memImport.shared
+  });
   const env = {
     wasm_dynarec_dispatch: () => {},
     memory,

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -490,7 +490,7 @@ START_TEST(test_compile_example)
 
     const char *wasm_path = "mupen64plus-core/test/wasm_dynarec/test_block.wasm";
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "wat2wasm %s -o %s", wat_path, wasm_path);
+    snprintf(cmd, sizeof(cmd), "wat2wasm %s --enable-threads -o %s", wat_path, wasm_path);
     int ret = system(cmd);
     ck_assert_msg(ret == 0, "wat2wasm failed: %d", ret);
 


### PR DESCRIPTION
## Summary
- import shared memory when emitting WAT for wasm dynarec blocks
- allocate a single `WebAssembly.Memory` in `wasm_dynarec_exec_js`
- instantiate blocks using that memory and simplify the JS dispatch helper

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec` *(fails: cp1_2, r9, r8, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ac4a026b8832bb221847164f7ddf7