### PR TITLE
Improve wasm dynarec block size

### DIFF
--- a/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/wasm_dynarec/wasm_dynarec.c
@@ -563,7 +563,7 @@ static struct wasm_dynarec_block *get_block(uint32_t address)
 }
 
 /* Return remaining instruction count from an existing block that
- * covers the given address, or 4 if no such block exists. */
+ * covers the given address, or 0x100 if no such block exists. */
 static size_t get_remaining_count(uint32_t address)
 {
     for (size_t i = 0; i < g_blocks_count; ++i) {
@@ -572,7 +572,7 @@ static size_t get_remaining_count(uint32_t address)
         if (address >= start && address < end)
             return g_blocks[i].iw_count - (address - start) / 4;
     }
-    return 4;
+    return 0x100;
 }
 
 #ifdef __EMSCRIPTEN__
@@ -3031,7 +3031,7 @@ void wasm_dynarec_dispatch(struct r4300_core *r4300, uint32_t address)
         //DebugMessage(M64MSG_INFO, "Dispatching WebAssembly dynarec block at address %08x", pc);
 
         if (!get_block(pc))
-            wasm_dynarec_recompile_block(r4300, code, 4, pc);
+            wasm_dynarec_recompile_block(r4300, code, 0x100, pc);
 
         wasm_dynarec_exec(r4300, pc);
 

--- a/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
+++ b/mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec.c
@@ -2207,6 +2207,32 @@ START_TEST(test_slti_sign)
 }
 END_TEST
 
+START_TEST(test_s1_countdown)
+{
+    const uint32_t block[] = {
+        0x24111f40, /* addiu s1, zero, 0x1f40 */
+        0x00000000, /* nop */
+        0x2231ffff, /* addi  s1, s1, -1 */
+        0x1620fffd, /* bnez  s1, -3 */
+        0x00000000  /* nop */
+    };
+
+    struct r4300_core *cpu = calloc(1, sizeof(*cpu));
+    ck_assert_ptr_nonnull(cpu);
+
+    wasm_dynarec_init(cpu);
+    wasm_dynarec_recompile_block(cpu, block, sizeof(block)/4, 0x80000000);
+
+    const char *wat = wasm_dynarec_get_wat(0x80000000);
+    ck_assert_ptr_nonnull(wat);
+    ck_assert_msg(strstr(wat, "2147483652"),
+                  "missing loop dispatch\n%s", wat);
+
+    wasm_dynarec_cleanup();
+    free(cpu);
+}
+END_TEST
+
 Suite *create_suite(void)
 {
     Suite *s = suite_create("WebAssembly Dynarec");
@@ -2243,6 +2269,7 @@ Suite *create_suite(void)
     tcase_add_test(tc_core, test_stack_rw);
     tcase_add_test(tc_core, test_stack_offset);
     tcase_add_test(tc_core, test_loop_stack);
+    tcase_add_test(tc_core, test_s1_countdown);
     tcase_add_test(tc_core, test_sumsq_c);
     tcase_add_test(tc_core, test_factorial_c);
     tcase_add_test(tc_core, test_fibonacci_c);


### PR DESCRIPTION
## Summary
- expand the default block size used by the wasm dynarec dispatcher
- reflect the larger block size in helper logic
- add a unit test covering a tight decrement loop and verify the generated WAT contains the expected dispatch

## Testing
- `make -C mupen64plus-core/test/wasm_dynarec test_wasm_dynarec`
- `mupen64plus-core/test/wasm_dynarec/test_wasm_dynarec`

------
https://chatgpt.com/codex/tasks/task_e_684ae012eedc832b86c12593ce72f89d